### PR TITLE
Added start script to package.json

### DIFF
--- a/bulletin-board-app/package.json
+++ b/bulletin-board-app/package.json
@@ -13,6 +13,9 @@
     "vue": "^1.0.10",
     "vue-resource": "^0.1.17"
   },
+  "scripts": {
+    "start": "node server.js"
+  },
   "devDependencies": {
     "body-parser": "^1.14.1",
     "errorhandler": "^1.4.2",


### PR DESCRIPTION
Docker run will fail with current package.json because it lacks a start script. This commit will fix this issue and in return will make the Getting Started guide usable again. For further info, see: https://github.com/docker/docker.github.io/issues/11628